### PR TITLE
Implement count flag for consuming multiple arguments

### DIFF
--- a/error.go
+++ b/error.go
@@ -56,6 +56,15 @@ const (
 	// a certain number of choices.
 	ErrInvalidChoice
 
+	// ErrInvalidCount indicates an invalid count.
+	ErrInvalidCount
+
+	// ErrInvalidCountDefault indicates that default value is not allowed for count.
+	ErrInvalidCountDefault
+
+	// ErrInvalidCountMap indicates that the count is invalid for map type.
+	ErrInvalidCountMap
+
 	// ErrInvalidTag indicates an invalid tag or invalid use of an existing tag
 	ErrInvalidTag
 )
@@ -90,6 +99,12 @@ func (e ErrorType) String() string {
 		return "unknown command"
 	case ErrInvalidChoice:
 		return "invalid choice"
+	case ErrInvalidCount:
+		return "invalid count"
+	case ErrInvalidCountDefault:
+		return "invalid default for count"
+	case ErrInvalidCountMap:
+		return "invalid count for map"
 	case ErrInvalidTag:
 		return "invalid tag"
 	}

--- a/flags.go
+++ b/flags.go
@@ -111,6 +111,8 @@ The following is a list of tags for struct fields supported by go-flags:
     choice:         limits the values for an option to a set of values.
                     Repeat this tag once for each allowable value.
                     e.g. `long:"animal" choice:"cat" choice:"dog"`
+    count:          the number of arguments for the value of the option. The value
+                    should be equal or larger than 1.
     hidden:         if non-empty, the option is not visible in the help or man page.
 
     base: a base (radix) used to convert strings to integer values, the

--- a/group.go
+++ b/group.go
@@ -7,6 +7,7 @@ package flags
 import (
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -276,6 +277,16 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 		optional := !isStringFalsy(mtag.Get("optional"))
 		required := !isStringFalsy(mtag.Get("required"))
 		choices := mtag.GetMany("choice")
+		var count int
+		if s := mtag.Get("count"); s != "" {
+			var err error
+			if count, err = strconv.Atoi(s); err != nil || count < 1 {
+				return newErrorf(ErrInvalidCount, "failed to parse count `%s'", s)
+			}
+			if len(def) > 0 {
+				return newError(ErrInvalidCountDefault, "cannot specify default and count")
+			}
+		}
 		hidden := !isStringFalsy(mtag.Get("hidden"))
 
 		option := &Option{
@@ -291,6 +302,7 @@ func (g *Group) scanStruct(realval reflect.Value, sfield *reflect.StructField, h
 			ValueName:        valueName,
 			DefaultMask:      defaultMask,
 			Choices:          choices,
+			Count:            count,
 			Hidden:           hidden,
 
 			group: g,


### PR DESCRIPTION
This pull request adds a new `count` flag for consuming multiple arguments. This is useful for constructing `map[string]int` from `cli -f str1 10 -f str2 20 args`.